### PR TITLE
Don't clean UTM as other services rely on UTMs existing e.g. Segment

### DIFF
--- a/global/utms@3.0.js
+++ b/global/utms@3.0.js
@@ -38,21 +38,11 @@
     document.cookie = cookieString;
   }
 
-  function cleanUtm() {
-    var cleanSearch = window.location.search
-      .replace(/utm_[^&]+&?/g, '')
-      .replace(/&$/, '')
-      .replace(/^\?$/, '');
-
-    window.history.replaceState({}, '', window.location.pathname + cleanSearch);
-  }
-
   window.addEventListener("load", function () {
     url = window.location.href;
     formattedUtmParams = formatUtmParameters(url);
     if (formattedUtmParams !== null) {
       trackUtm(formattedUtmParams);
-      cleanUtm()
     }
     setLandingPage();
   })


### PR DESCRIPTION
**Why:** UTMs are not being sent as part of page loads in Segment. They are cleared from the URL by the UTM script.

**What:** Stopped UTMs from being cleared. It's a messier URL but otherwise shouldn't cause any issues.