### PR TITLE
Reduce cookie banner delay to improve LCP

### DIFF
--- a/global/cookie-banner@3.0.js
+++ b/global/cookie-banner@3.0.js
@@ -71,5 +71,5 @@
     }
   )
 
-  setTimeout(loadCookieBanner, 3000);
+  setTimeout(loadCookieBanner, 1);
 }();


### PR DESCRIPTION
**Why:** Core Web Vitals LCP (largest contentful pain) score might be affected by the delayed paint of the cookie banner.

**What:** Reduced cookie banner timeout, but kept it there to delay it after other scripts