### PR TITLE
Handle member alerts on employers/signup

### DIFF
--- a/offerzen/global/employers/employers-signup-member-alerts@1.0.js
+++ b/offerzen/global/employers/employers-signup-member-alerts@1.0.js
@@ -21,7 +21,7 @@
 
       //clean url
       const url = new URL(window.location);
-      url.searchParam.delete('member');
+      url.searchParams.delete('member');
       window.history.replaceState(null, null, url);
     }
 

--- a/offerzen/global/employers/employers-signup-member-alerts@1.0.js
+++ b/offerzen/global/employers/employers-signup-member-alerts@1.0.js
@@ -1,12 +1,12 @@
 !(function () {
   window.$loaded(function (window, document, $, undefined) {
-    const params = new URLSearchParams(window.location.search);
+    const searchParams = new URLSearchParams(window.location.search);
     $('.js-member-alert-message').val('');
 
-    if (params.has('member')) {
-      const alert = params.get('member');
+    if (searchParams.has('member')) {
+      const memberAlert = searchParams.get('member');
       //show the relevant message based on alert
-      switch (alert) {
+      switch (memberAlert) {
         case 'invalid_token':
           $('.js-member-alert-message').text('This invite has been used already.');
           $('.js-member-alert').show();
@@ -20,16 +20,10 @@
       }
 
       //clean url
-      var cleanSearch = window.location.search
-        .replace(/member[^&]+&?/g, '')
-        .replace(/&$/, '')
-        .replace(/^\?$/, '');
-
-      window.history.replaceState(
-        {},
-        '',
-        window.location.pathname + cleanSearch
-      );
+      searchParams.delete('member');
+      const url = new URL(window.location);
+      url.searchParams = searchParams;
+      window.history.replaceState({}, '', url.pathname + url.search); // includes `?`
     }
 
     //handle close alert icon

--- a/offerzen/global/employers/employers-signup-member-alerts@1.0.js
+++ b/offerzen/global/employers/employers-signup-member-alerts@1.0.js
@@ -20,10 +20,9 @@
       }
 
       //clean url
-      searchParams.delete('member');
       const url = new URL(window.location);
-      url.searchParams = searchParams;
-      window.history.replaceState({}, '', url.pathname + url.search); // includes `?`
+      url.searchParam.delete('member');
+      window.history.replaceState(null, null, url);
     }
 
     //handle close alert icon

--- a/offerzen/global/employers/employers-signup-member-alerts@1.0.js
+++ b/offerzen/global/employers/employers-signup-member-alerts@1.0.js
@@ -1,0 +1,45 @@
+!(function () {
+  window.$loaded(function (window, document, $, undefined) {
+    const params = new URLSearchParams(window.location.search);
+    $('js-member-alert-message').val('');
+
+    if (params.has('member')) {
+      const alert = params.get('member');
+      //show the relevant message based on alert
+      switch (alert) {
+        case 'invalid_token':
+          $('.js-member-alert-message').text(
+            'This invite has been used already.'
+          );
+          $('.js-member-alert').show();
+          break;
+        case 'already_exists':
+          $('.js-member-alert-message').text(
+            "You've already been added as a member."
+          );
+          $('.js-member-alert').show();
+          break;
+        default:
+          return;
+      }
+
+      //clean url
+      var cleanSearch = window.location.search
+        .replace(/member[^&]+&?/g, '')
+        .replace(/&$/, '')
+        .replace(/^\?$/, '');
+
+      window.history.replaceState(
+        {},
+        '',
+        window.location.pathname + cleanSearch
+      );
+    }
+
+    //handle close alert icon
+    $('.js-close-alert').on('click', this, function (e) {
+      e.preventDefault();
+      $('.js-member-alert').hide();
+    });
+  });
+})();

--- a/offerzen/global/employers/employers-signup-member-alerts@1.0.js
+++ b/offerzen/global/employers/employers-signup-member-alerts@1.0.js
@@ -1,7 +1,7 @@
 !(function () {
   window.$loaded(function (window, document, $, undefined) {
     const params = new URLSearchParams(window.location.search);
-    $('js-member-alert-message').val('');
+    $('.js-member-alert-message').val('');
 
     if (params.has('member')) {
       const alert = params.get('member');

--- a/offerzen/global/employers/employers-signup-member-alerts@1.0.js
+++ b/offerzen/global/employers/employers-signup-member-alerts@1.0.js
@@ -8,15 +8,11 @@
       //show the relevant message based on alert
       switch (alert) {
         case 'invalid_token':
-          $('.js-member-alert-message').text(
-            'This invite has been used already.'
-          );
+          $('.js-member-alert-message').text('This invite has been used already.');
           $('.js-member-alert').show();
           break;
         case 'already_exists':
-          $('.js-member-alert-message').text(
-            "You've already been added as a member."
-          );
+          $('.js-member-alert-message').text("You've already been added as a member.");
           $('.js-member-alert').show();
           break;
         default:


### PR DESCRIPTION
This script shows the relevant alert message depending if the 'member' param exists.
The two cases where the message will show is if params 'member' = invalid_token or already_exists
It also then cleans the url after handling the alert to be displayed.

The alert looks like the following with a close icon:
<img width="1128" alt="Screenshot 2022-08-04 at 11 12 28" src="https://user-images.githubusercontent.com/82391266/182812469-1ab47954-0096-4e6b-b333-b19e32f26de1.png">

Corresponding PR on zadev for the redirect
https://github.com/offerzen/zadev/pull/10999