### PR TITLE
Targets first step button

### DIFF
--- a/offerzen/global/employers/employers-submit@1.3B.js
+++ b/offerzen/global/employers/employers-submit@1.3B.js
@@ -1,0 +1,12 @@
+(function () {
+  const button = document.querySelector(
+    '.js-multi-step-lead-continue-button'
+  );
+  button.setAttribute('disabled', 'disabled');
+  const label = button.value;
+  button.value = 'Loading...';
+
+  window.multiStepCompanyLeadFormLoaded = function () {
+    button.value = label;
+  };
+})();


### PR DESCRIPTION
**Why** Multistep forms can be submitted before the JS has loaded

**What** Prevent step 1's continue button from being clicked early. Keeps previous 1.2B script around just for transition (jsdelivr gets crazy with deletion)

Moves the script from "step2" to "step1" in Webflow