### PR TITLE
Remove json parse to fix segment page load event with location

### DIFF
--- a/global/segment-with-location@2.0.js
+++ b/global/segment-with-location@2.0.js
@@ -14,14 +14,8 @@
       type: 'GET',
       url: '/api/user_location',
       content_type: 'application/json',
-      success: function (data) {
-        try {
-          var properties = JSON.parse(data);
-          analytics.page('landing', properties);
-        }
-        catch (e) {
-          analytics.page('landing');
-        }
+      success: function (properties) {
+        analytics.page('landing', properties);
       },
       error: function () {
         analytics.page('landing');


### PR DESCRIPTION
Remove json parse to fix segment page load event with location

The endpoint /api/user_location is returning an object that doesn't need Json.parse