### PR TITLE
Cater for existing CTA tracking & distinct tracking for Mega nav links

### DIFF
--- a/global/cta-analytics@1.0.js
+++ b/global/cta-analytics@1.0.js
@@ -1,0 +1,41 @@
+!function () {
+  window.$loaded(function (window, document, $, undefined) {
+    var ready = function () {
+      (function trackAnalytics() {
+        function trackElement () {
+          var link = $(this);
+          var name = link.attr('data-name');
+          var category = link.attr('data-category');
+          var action = link.attr('data-action');
+          var source = link.attr('data-source');
+          var label = link.attr('data-label');
+          var source_detail = link.attr('data-source-detail');
+          var href = link.attr('href');
+
+          var properties = { category, action, source, label, source_detail };
+
+          link.one('click', function (e) {
+            e.preventDefault();
+            e.stopImmediatePropagation();
+
+            analytics.track(
+              name,
+              properties,
+              { integrations: { Intercom: false } },
+              function () {
+                return window.location.href = href;
+              }
+            );
+          });
+        }
+
+        // Some pages use -cta, some use -nav
+        $('[data-js="track-nav"]').each(trackElement);
+        $('[data-js="track-cta"]').each(trackElement);
+      })();
+    };
+
+    $(document).ready(ready);
+    $(document).on('page:load', ready);
+  });
+}();

--- a/global/navigation@4.0.js
+++ b/global/navigation@4.0.js
@@ -1,0 +1,139 @@
+!(function () {
+  window.$loaded(function (window, document, $, undefined) {
+    const body = $(document.body);
+    const nav = $('.js-navbar');
+
+    const conversionContainer = nav.find('.js-conversion-dropdown');
+    const conversionButton = nav.find('.js-conversion-button');
+
+    const menu = nav.find('.items-container');
+    const menuButton = nav.find('.js-menu-button');
+    const menuOpenIcon = nav.find('.open-icon');
+    const menuCloseIcon = nav.find('.close-icon');
+
+    function showOpenIcon() {
+      menuOpenIcon.show();
+      menuCloseIcon.hide();
+      $('.intercom-lightweight-app').show();
+    }
+
+    function showCloseIcon() {
+      menuCloseIcon.show();
+      menuOpenIcon.hide();
+      $('.intercom-lightweight-app').hide();
+    }
+
+    function setMenuHeight() {
+      if ($(window).width() <= 991) {
+        menu.css('height', window.innerHeight - 61);
+      } else {
+        menu.css('height', 'auto');
+      }
+    }
+
+    // ------------------
+    // Actions when hamburger button is clicked
+    // ------------------
+
+    menuButton.on('click', function () {
+      // Close conversion mega menu when mobile menu is open
+      if (conversionContainer.attr('data-visible') === 'true') {
+        conversionContainer.attr('data-visible', 'false')
+      }
+      
+      // Delay actions to make sure Webflow has finished it's click event
+      setTimeout(() => {
+        if (menuButton.hasClass('w--open')) {
+          body.addClass('no-scroll');
+          showCloseIcon();
+        } else {
+          body.removeClass('no-scroll');
+          showOpenIcon();
+        }
+        setMenuHeight();
+      }, 30);
+    });
+
+    // ------------------
+    // Custom 'sign up' conversion mega menu
+    // ------------------
+
+    conversionButton.on('click', function () {
+       if (conversionContainer.attr('data-visible') === 'false') {
+         conversionContainer.attr('data-visible', 'true');
+       } else {
+         conversionContainer.attr('data-visible', 'false');
+       }
+       
+      // Check if menu is open, close it and open conversion
+      if (menuButton.hasClass('w--open')) {
+        showOpenIcon();
+        menuButton.triggerHandler('tap');
+        conversionContainer.attr('data-visible', 'true');
+      }
+    });
+
+    // Close conversion mega menu if click anywhere outside
+    document.addEventListener('click', function (event) {
+      if (
+        event.target.closest('.js-conversion-dropdown') ||
+        event.target.closest('.js-sign-up-button')
+      ) {
+        return;
+      }
+      conversionContainer.attr('data-visible', 'false');
+    });
+
+    // ------------------
+    // Analytics
+    // ------------------
+
+    const ready = function () {
+      (function trackAnalytics() {
+        function onElementClick() {
+          let name = nav.find('.js-analytics-props-name-full-nav').text();
+          let category = nav
+            .find('.js-analytics-props-category-full-nav')
+            .text();
+          let source_detail = nav
+            .find('.js-analytics-props-source-detail-full-nav')
+            .text();
+          let link = $(this);
+          let action =
+            link.attr('data-action') ??
+            link.find('.js-analytics-props-data-action').text();
+          let label = window.location.href;
+
+          let properties = { category, action, label, source_detail };
+
+          analytics.track(name, properties, {
+            integrations: { Intercom: false },
+          });
+        }
+
+        function trackElement() {
+          let link = $(this);
+          link.on('click', onElementClick);
+        }
+
+        $('[data-js="navigation-tracking"]').each(trackElement);
+      })();
+
+      function debounce(func, timeout = 10) {
+        let timer;
+        return (...args) => {
+          clearTimeout(timer);
+          timer = setTimeout(() => {
+            func.apply(this, args);
+          }, timeout);
+        };
+      }
+
+      setMenuHeight();
+      $(window).on('resize', debounce(setMenuHeight, 40));
+    };
+
+    $(document).ready(ready);
+    $(document).on('page:load', ready);
+  });
+})();


### PR DESCRIPTION

🏗️ **Changed**

- navigation@3.0.js ==> navigation@4.0.js
- One line of code change, Line 119, from data-js="track-nav" to data-js="navigation-tracking" 
- Added cta-analytics@1.0.js

🌍 **Why**
Added new script to be included on webflow pages for catering for analytics tracking of existing call to actions.
Previously we were reusing the nav tracking logic for buttons and links on pages, which is why we have to keep the data attributes separate. 

Aka, any button or link that had data attribute data-js="track-nav"  or data-js="track-cta" , we would use the existing nav script to track analytics. This PR is to extract that piece of code into its own script: cta-analytics@1.0.js

Then, we have updated the data attribute of the mega menu nav links to be unique: data-js="navigation-tracking" 

**This is to prevent any existing tracking from breaking.**

