### PR TITLE
Navigation breadcrumbs 🍞

### DIFF
--- a/global/navigation@4.0.css
+++ b/global/navigation@4.0.css
@@ -1,0 +1,112 @@
+.w-nav-overlay {
+  overflow: scroll !important;
+  position: fixed;
+  top: 62px;
+}
+
+.no-scroll {
+  overflow: hidden;
+  position: fixed;
+  width: 100%;
+}
+
+.link-block-right:hover .link-block-right-title {
+  font-weight: 600 !important;
+}
+
+.featured-link:hover .featured-title {
+  font-weight: 600 !important;
+}
+
+.conversion-item-mobile:hover .tick-icon,
+.conversion-item-mobile:focus .tick-icon,
+.conversion-item:hover .tick-icon-desktop,
+.conversion-item:focus .tick-icon-desktop {
+  display: block;
+}
+
+.conversion-item:hover {
+  font-weight: 600;
+}
+
+.nav-dropdown-container {
+  box-shadow: 4px 4px 20px rgba(11, 18, 54, 0.5);
+}
+
+.js-conversion-dropdown[data-visible='false'] {
+  display: none;
+}
+
+.js-conversion-dropdown[data-visible='true'] {
+  display: block;
+}
+
+.current-parent {
+  font-weight: 600;
+  border-bottom: 2px solid #2f96f4;
+  color: #fff;
+}
+
+.current-link {
+  background-color: rgba(47, 150, 244, 0.15);
+  font-weight: 600;
+}
+
+.link-block-right.current-link .link-block-right-title {
+  font-weight: 600;
+}
+
+.link-block-right.current-link .featured-image-icon-default {
+  opacity: 0 !important;
+}
+
+.link-block-right.current-link .featured-image-icon-hover {
+  opacity: 1 !important;
+}
+
+@media (max-width: 1125px) {
+  .nav-dropdown-container.three-col.w--open {
+    left: -485px;
+  }
+}
+@media (max-width: 991px) {
+  .current-parent {
+    font-weight: 600;
+    border-bottom: 2px solid rgba(47, 150, 244, 0.2);
+    color: #fff;
+  }
+  
+  .current-parent .toggle-title-icon {
+    opacity: 0 !important;
+  }
+  
+  .current-parent .toggle-title-icon-hover {
+    opacity: 1 !important;
+  }
+  
+  .items-container {
+    overflow: scroll;
+  }
+  
+  [data-nav-menu-open] {
+    height: inherit;
+    display: flex !important;
+    flex-direction: column;
+    justify-content: space-between;
+  }
+
+  .nav-dropdown {
+    width: 100%;
+  }
+}
+
+@media (max-width: 320px) {
+  .mobile-cta-container {
+    flex-direction: column;
+  }
+
+  .conversion-sign-up-button-mobile,
+  .login-button-mobile {
+    width: 100%;
+  }
+}

--- a/global/navigation@5.0.js
+++ b/global/navigation@5.0.js
@@ -1,0 +1,186 @@
+!(function () {
+  window.$loaded(function (window, document, $, undefined) {
+    const body = $(document.body);
+    const nav = $('.js-navbar');
+
+    const conversionContainer = nav.find('.js-conversion-dropdown');
+    const conversionButton = nav.find('.js-conversion-button');
+
+    const menu = nav.find('.items-container');
+    const menuButton = nav.find('.js-menu-button');
+    const menuOpenIcon = nav.find('.open-icon');
+    const menuCloseIcon = nav.find('.close-icon');
+
+    function showOpenIcon() {
+      menuOpenIcon.show();
+      menuCloseIcon.hide();
+      $('.intercom-lightweight-app').show();
+    }
+
+    function showCloseIcon() {
+      menuCloseIcon.show();
+      menuOpenIcon.hide();
+      $('.intercom-lightweight-app').hide();
+    }
+
+    function setMenuHeight() {
+      if ($(window).width() <= 991) {
+        menu.css('height', window.innerHeight - 61);
+      } else {
+        menu.css('height', 'auto');
+      }
+    }
+
+    // ------------------
+    // Actions when hamburger button is clicked
+    // ------------------
+
+    menuButton.on('click', function () {
+      // Close conversion mega menu when mobile menu is open
+      if (conversionContainer.attr('data-visible') === 'true') {
+        conversionContainer.attr('data-visible', 'false');
+      }
+
+      // Delay actions to make sure Webflow has finished it's click event
+      setTimeout(() => {
+        if (menuButton.hasClass('w--open')) {
+          body.addClass('no-scroll');
+          showCloseIcon();
+        } else {
+          body.removeClass('no-scroll');
+          showOpenIcon();
+        }
+        setMenuHeight();
+      }, 30);
+    });
+
+    // ------------------
+    // Custom 'sign up' conversion mega menu
+    // ------------------
+
+    conversionButton.on('click', function () {
+      if (conversionContainer.attr('data-visible') === 'false') {
+        conversionContainer.attr('data-visible', 'true');
+      } else {
+        conversionContainer.attr('data-visible', 'false');
+      }
+
+      // Check if menu is open, close it and open conversion
+      if (menuButton.hasClass('w--open')) {
+        showOpenIcon();
+        menuButton.triggerHandler('tap');
+        conversionContainer.attr('data-visible', 'true');
+      }
+    });
+
+    // Close conversion mega menu if click anywhere outside
+    document.addEventListener('click', function (event) {
+      if (
+        event.target.closest('.js-conversion-dropdown') ||
+        event.target.closest('.js-sign-up-button')
+      ) {
+        return;
+      }
+      conversionContainer.attr('data-visible', 'false');
+    });
+
+    // ------------------
+    // Nav breadcrumbs / highlight
+    // ------------------
+    
+    // Check if the link contains offerzen.com
+    function isOnDomain(href) {
+      let isValid = href.match(/^https:\/\/www\.offerzen\.com/) != null;
+
+      isValid ||= href.match(/^\//) != null;
+
+      return isValid;
+    }
+
+    function checkLinkMatch(linkHref) {
+      if (!isOnDomain(linkHref)) {
+        return false;
+      }
+
+      if (linkHref.match(/^\//)) {
+        linkHref = `https://www.offerzen.com/${linkHref}`;
+      }
+
+      // Removes search params or UTMs
+      const pageHref = `${window.location.origin}${window.location.pathname}`;
+
+      return pageHref === linkHref;
+    }
+    
+    function highlightCurrentLink () {
+      const navLinks = $('[data-js="nav-dropdown-container"]').find('a');
+
+      navLinks.each(function () {
+        const link = $(this);
+        const linkURL = link.attr('href');
+        
+        if(checkLinkMatch(linkURL)) {
+           link
+             .closest('[data-js="nav-dropdown"]')
+             .find('[data-js="nav-dropdown-toggle"]')
+             .addClass('current-parent');
+           link.addClass('current-link');
+        }
+      });
+    }
+
+    // ------------------
+    // Analytics
+    // ------------------
+
+    const ready = function () {
+      (function trackAnalytics() {
+        function onElementClick() {
+          let name = nav.find('.js-analytics-props-name-full-nav').text();
+          let category = nav
+            .find('.js-analytics-props-category-full-nav')
+            .text();
+          let source_detail = nav
+            .find('.js-analytics-props-source-detail-full-nav')
+            .text();
+          let link = $(this);
+          let action =
+            link.attr('data-action') ??
+            link.find('.js-analytics-props-data-action').text();
+          let label = window.location.href;
+
+          let properties = { category, action, label, source_detail };
+
+          analytics.track(name, properties, {
+            integrations: { Intercom: false },
+          });
+        }
+
+        function trackElement() {
+          let link = $(this);
+          link.on('click', onElementClick);
+        }
+
+        $('[data-js="navigation-tracking"]').each(trackElement);
+      })();
+
+      function debounce(func, timeout = 10) {
+        let timer;
+        return (...args) => {
+          clearTimeout(timer);
+          timer = setTimeout(() => {
+            func.apply(this, args);
+          }, timeout);
+        };
+      }
+
+      setMenuHeight();
+      $(window).on('resize', debounce(setMenuHeight, 40));
+      
+      highlightCurrentLink();
+    };
+
+    $(document).ready(ready);
+    $(document).on('page:load', ready);
+  });
+})();


### PR DESCRIPTION
### 🏗️ Changed
Added code that compares the user's current URL with the links in the navigation, and applies classes to the dropdown trigger, and menu item if there is a match.

### 🌍 Why
User knows if they're on a page that exists in the menu.
Breadcrumbs 🍞

### 🧪 Testing
Bit of a weird one to test - has to be done on production environment, because the URLs on staging will not match the URLs in the menu.

**A testing case you can try:**
👉 Navigate to https://www.offerzen.com/community
👉 This page is on the menu here
![Screenshot 2022-10-17 at 10 34 05](https://user-images.githubusercontent.com/43538692/196129827-41a8ce0d-4d1e-42f3-98a3-76ab00dfcc49.png)
👉 Therefore, the menu item inside the dropdown should be highlighted, and the parent dropdown toggle should also be highlighted
👉 You can run the functions `isOnDomain(), checkLinkMatch()` and `highlightCurrentLink()` in the browser console. Then call `highlightCurrentLink()`. Like so:
![Screenshot 2022-10-17 at 10 53 19](https://user-images.githubusercontent.com/43538692/196134056-6c3db3b5-e6c9-4dc8-9362-61c24e18c5aa.png)


**Expected result:**
✅  The .current-parent class is applied to the Community navigation dropdown
✅  The .current-link class should be applied to the 'About Offerzen community' dropdown menu item