### PR TITLE
Original and amended FB Pixel Base code to prevent GTM robot traffic

### DIFF
--- a/global/facebook-pixel@1.0.js
+++ b/global/facebook-pixel@1.0.js
@@ -1,0 +1,12 @@
+if(typeof fbq === 'undefined') {
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '469836106522436');
+  fbq('track', 'PageView');
+}

--- a/global/facebook-pixel@2.0.js
+++ b/global/facebook-pixel@2.0.js
@@ -1,4 +1,4 @@
-if(typeof fbq === 'undefined' && document.location.href.search('gtm-msr.appspot') == -1) {
+if(typeof fbq === 'undefined' && !document.location.origin.includes('gtm-msr.appspot')) {
   !function(f,b,e,v,n,t,s)
   {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
   n.callMethod.apply(n,arguments):n.queue.push(arguments)};

--- a/global/facebook-pixel@2.0.js
+++ b/global/facebook-pixel@2.0.js
@@ -1,0 +1,12 @@
+if(typeof fbq === 'undefined' && document.location.href.search('gtm-msr.appspot') == -1) {
+  !function(f,b,e,v,n,t,s)
+  {if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+  n.callMethod.apply(n,arguments):n.queue.push(arguments)};
+  if(!f._fbq)f._fbq=n;n.push=n;n.loaded=!0;n.version='2.0';
+  n.queue=[];t=b.createElement(e);t.async=!0;
+  t.src=v;s=b.getElementsByTagName(e)[0];
+  s.parentNode.insertBefore(t,s)}(window, document,'script',
+  'https://connect.facebook.net/en_US/fbevents.js');
+  fbq('init', '469836106522436');
+  fbq('track', 'PageView');
+}


### PR DESCRIPTION
**Why**❓🤔
THIS IS TO STORE THE ORIGINAL AND NEW SCRIPTS IN THE CDN.

Facebook Pixel has been previously implemented using GTM, view the 1.0 version of the script. 
The Facebook Pixel Base Code tag an be found here: https://tagmanager.google.com/#/container/accounts/1959241284/containers/7797698/workspaces/325/tags

After implementing the Conversions Api to pipe through server events to Facebook, we see that there is some Google robot traffic spiking the data on Facebook Events Manager (check url  "https://gtm-msr.appspot.com/render...").

<img width="965" alt="Screenshot 2022-10-18 at 11 37 52" src="https://user-images.githubusercontent.com/82391266/196400186-339a6624-19f8-456b-a4d5-f7257de7e9a9.png">

<img width="681" alt="Screenshot 2022-10-18 at 11 38 11" src="https://user-images.githubusercontent.com/82391266/196400260-99389b8a-bf28-4fec-b77a-4fee19762a17.png">

**Suggested fix** 🔨 🧰 
Exclude all traffic from gtm-msr.appspot in the Facebook Pixel Base Code script, view the 2.0 version of the script

**Some references for more context**:
https://www.linkedin.com/pulse/how-remove-google-robot-problem-via-gtm-facebook-pixel-hjelpdahl/
https://www.youtube.com/watch?v=b4I1ePZt8Z0



