### PR TITLE
Feature/fast track access employer form

### DIFF
--- a/offerzen/global/company-fast-track-access/company-prospect-form@v0.js
+++ b/offerzen/global/company-fast-track-access/company-prospect-form@v0.js
@@ -1,30 +1,24 @@
 (function () {
   // FORM TARGETTING
-  const leadFormId = '#Company-Prospect-Form';
+  const prospectFormId = '#Company-Prospect-Form';
   const pageRef = 'onSubmitCompanyProspectForm';
-  const formSubmitButtonSelector = 'input[type=submit]';
+  const formSubmitButtonSelector = '#submit-button';
   const formContainerClass = '.js-company-prospect-form';
-  let timeout_interval = 1000;
   // END FORM TARGETING
-
   // This needs to run regardless of whether JQuery has loaded
   // Disable button
   const button = document.querySelector(
-    `${leadFormId} ${formSubmitButtonSelector}`
+    `${prospectFormId} ${formSubmitButtonSelector}`
   );
   button.setAttribute('disabled', 'disabled');
   const label = button.value;
   button.value = 'Loading...';
-
   function enableSubmitButton() {
     button.value = label;
     button.removeAttribute('disabled');
   }
-
   // ------------------------------------------------------------------------------------------
   window.$loaded(function () {
-    window.hasLoadedSelect2 = window.hasLoadedSelect2 ?? false;
-
     window.$parsleyLoaded = function (cb) {
       setTimeout(() => {
         if (window.Parsley && window.ParsleyValidator) {
@@ -34,25 +28,25 @@
         $parsleyLoaded(cb);
       }, 50);
     };
-
     window.$parsleyLoaded(function (window, document, parsley) {
-      const form = $(leadFormId);
-      const formContainer = $(formContainerClass)
-
+      const form = $(prospectFormId);
+      const formContainer = $(formContainerClass);
       const formSubmitButton = form.find(formSubmitButtonSelector);
+      // Store button labels for state changes
+      let initialButtonValue = formSubmitButton.attr('data-initial');
+      let dataWait = formSubmitButton.attr('data-wait');
+      let dataBusy = formSubmitButton.attr('data-busy');
 
       function trackSubmission() {
         var emailValue = form.find('#email').val();
         var isPlaywrightTest =
           emailValue.match(/^\s*playwrighttest@offerzen\.com\s*$/i) != null;
-
         if (!isPlaywrightTest) {
           var event = form.find('.js-analytics-event').text();
           var action = form.find('.js-analytics-action').text();
           var label = form.find('.js-analytics-label').text();
           var category = form.find('.js-analytics-category').text();
           var source = form.find('.js-analytics-source').text();
-
           dataLayer.push({
             event: event || 'Company Lead Form Submitted',
             action: action || 'Lead Form Submitted',
@@ -62,24 +56,76 @@
           });
         }
       }
+      function startProspectPolling(prospectId) {
+        const errorText = formContainer.find('.js-form-error');
+        const poll = function () {
+          $.ajax({
+            type: 'GET',
+            url: `/api/company/prospects/${prospectId}`,
+            contentType: 'application/json',
+            headers: {
+              Accept: 'application/json',
+            },
+            statusCode: {
+              200: function (data) {
+                clearInterval(pollInterval);
+                trackSubmission();
+                window.location.pathname = '/hire-developers/get-started';
+              },
+              401: function (data) {
+                const responseData = data.responseJSON;
+                formSubmitButton.attr('disabled', false);
+                formSubmitButton.text(initialButtonValue);
+                if (responseData.error == 'invalid_address') {
+                  errorText.text(
+                    "Oops! We couldn't validate your email. Please check that you are using your work email, then try again."
+                  );
+                  errorText.show();
+                } else {
+                  errorText.text(
+                    'This looks like a personal email address. Please use your work email address.'
+                  );
+                  errorText.show();
+                }
+                clearInterval(pollInterval);
+              },
+              404: function () {
+                formSubmitButton.attr('disabled', false);
+                formSubmitButton.text(initialButtonValue);
+                errorText.text(
+                  'Oops! Something went wrong while submitting the form.'
+                );
+                errorText.show();
+                clearInterval(pollInterval);
+              },
+            },
+          });
+        };
+        pollInterval = setInterval(function () {
+          poll();
+        }, 1000);
+        poll();
+      }
 
       function onSubmitForm(token, e) {
         formSubmitButton.attr('disabled', true);
         window.pageVariantMeasureEnd = btoa(new Date().getTime() / 1000);
-        let initialButtonValue = formSubmitButton.attr('value');
-        let dataWait = formSubmitButton.attr('data-wait');
-        formSubmitButton.attr('value', dataWait);
+
+        formSubmitButton.text(dataWait);
+
         // get the value of the report_source query parameter should it be present and forward it onto form lead submission for analytics
         let searchParams = new URLSearchParams(window.location.search);
         const formData = new FormData(form[0]);
         const formProperties = Object.fromEntries(formData.entries());
-
         form.find('.recaptcha-error').hide();
-        form.find('.js-submit-error').hide();
-
+        formContainer.find('.js-form-error').hide();
         if (form.parsley().validate()) {
+          // Setting submit button label
+          let buttonLabelTimer = setTimeout(function () {
+            formSubmitButton.text(dataBusy);
+          }, 1000);
+          // Hide errors
           form.find('.js-missing-fields').hide();
-
           const prospectProperties = Object.assign({}, formProperties, {
             referrer: location.href,
             report_source: searchParams.get('report_source'),
@@ -88,7 +134,6 @@
             },
             page_variant_meta: `${window.pageVariantMeasureStart}-optimize-meta-${pageVariantMeasureEnd}`,
           });
-
           $.ajax({
             type: 'POST',
             url: '/api/company/prospects',
@@ -98,69 +143,31 @@
               Accept: 'application/json',
             },
             success: function (data) {
-                setTimeout(() => {
-                  if (data.id) {
-                    $.ajax({
-                      type: 'GET',
-                      url: `/api/company/prospects/${data.id}`,
-                      contentType: 'application/json',
-                      headers: {
-                        Accept: 'application/json',
-                      },
-                      success: function (data) {
-                        switch (data.status) {
-                          case 401:
-                            formSubmitButton.attr('disabled', false);
-                            formSubmitButton.attr('value', initialButtonValue);
-                            const errorText = formContainer.find('.js-form-error')
-                            if (data.error == 'invalid_address') {
-                              errorText.text('Oops! We couldn’t validate your email. Please check that you are using your work email, then try again.')
-                              errorText.show();
-                            } else {
-                              errorText.text('This looks like a personal email address. Please use your work email address.')
-                              errorText.show();
-                            }
-                            break;
-                          case 200:
-                            //localStorage.setItem('prospect_id', .prospectId);
-                            trackSubmission();
-                            window.location.pathname = '/hire-developers/get-started';
-                            break;
-                          case 304:
-                          default:
-                            setPolling({
-                              ...polling,
-                              timeEllapsed: polling.timeEllapsed + pollingIntervalTime,
-                            });
-                        }
-                      },
-                    });
-                    
-                    return
-                  }
-                }, timeout_interval)
-                
+              $('.w-form-done').hide();
+              form.show();
+              if (data.id) {
+                startProspectPolling(data.id);
               }
             },
             // Reset form
             error: function (data) {
               formSubmitButton.attr('disabled', false);
-              formSubmitButton.attr('value', initialButtonValue);
+              formSubmitButton.text(initialButtonValue);
+              clearTimeout(buttonLabelTimer);
 
               if (data.recaptcha_verify) {
                 form.find('.recaptcha-error').show();
               } else {
-                form.find('.js-submit-error').show();
+                formContainer.find('.js-form-error').show();
               }
             },
           });
         } else {
           form.find('.js-missing-fields').show();
           formSubmitButton.attr('disabled', false);
-          formSubmitButton.attr('value', initialButtonValue);
+          formSubmitButton.text(initialButtonValue);
         }
       }
-
       function updateSubscribeToHiringInsightsField() {
         subscribeToCompanyNewsletter = form.find(
           '#subscribe_to_company_newsletter'
@@ -169,7 +176,6 @@
           form.find('#subscribe_to_hiring_insights').val(this.value);
         });
       }
-
       function matchCheckboxStates() {
         form.find('.w-checkbox').each(function () {
           const el = $(this);
@@ -181,20 +187,17 @@
           }
         });
       }
-
       // ------------------------------------------------------------
       // Setup form
       // ------------------------------------------------------------
-
       (function init() {
         // Check Recaptcha error
         const urlParams = new URLSearchParams(window.location.search);
         if (urlParams.has('r')) {
           form.find('.recaptcha-error').show();
         }
-
         function onFormReady() {
-          form.on('submit', function (e) {
+          formSubmitButton.one('click', function (e) {
             e.preventDefault();
             grecaptcha.ready(function () {
               grecaptcha
@@ -206,16 +209,12 @@
                 });
             });
           });
-
           enableSubmitButton();
         }
-
         updateSubscribeToHiringInsightsField();
         matchCheckboxStates();
-
         // Still needed for other parts of the page
         window[pageRef] = onSubmitForm;
-
         onFormReady();
       })();
     });

--- a/offerzen/global/company-fast-track-access/company-prospect-form@v0.js
+++ b/offerzen/global/company-fast-track-access/company-prospect-form@v0.js
@@ -122,7 +122,7 @@
           // Setting submit button label
           let buttonLabelTimer = setTimeout(function () {
             formSubmitButton.text(dataBusy);
-          }, 1000);
+          }, 5000);
           // Hide errors
           form.find('.js-missing-fields').hide();
           const prospectProperties = Object.assign({}, formProperties, {

--- a/offerzen/global/company-fast-track-access/company-prospect-form@v0.js
+++ b/offerzen/global/company-fast-track-access/company-prospect-form@v0.js
@@ -109,9 +109,8 @@
 
       function onSubmitForm(token, e) {
         formSubmitButton.attr('disabled', true);
-        window.pageVariantMeasureEnd = btoa(new Date().getTime() / 1000);
-
         formSubmitButton.text(dataWait);
+        window.pageVariantMeasureEnd = btoa(new Date().getTime() / 1000);
 
         // get the value of the report_source query parameter should it be present and forward it onto form lead submission for analytics
         let searchParams = new URLSearchParams(window.location.search);

--- a/offerzen/global/employers/ab-tests@1.2.js
+++ b/offerzen/global/employers/ab-tests@1.2.js
@@ -1,0 +1,28 @@
+// This is to initialize the gtag script, which is required in order to run A/B test experiments using Google Optimize
+// This is used in both employers pages, on the za page, as well as the nl page
+!function(){
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'UA-68966060-1');
+
+
+  window.$loaded(function (window, document, $, undefined) {
+    window.pageVariantMeasureStart = null;
+    window.pageVariantMeasureEnd = null;
+    const setTimeToInteract = function() {
+      if (window.pageVariantMeasureStart == null) {        
+
+        window.pageVariantMeasureStart = btoa((new Date().getTime() / 1000));
+      }
+    }
+
+    const setTimeToSubmit = function() {
+      window.pageVariantMeasureEnd = btoa((new Date().getTime() / 1000));
+    }
+
+    $("input, select").on("click focus", setTimeToInteract);
+    $(".company-form-email-only form, .js-company-signup-original form, .js-company-prospect-form form").on("submit", setTimeToSubmit);
+  });
+}();

--- a/offerzen/global/employers/company-prospect@1.0.js
+++ b/offerzen/global/employers/company-prospect@1.0.js
@@ -1,0 +1,223 @@
+(function () {
+  // FORM TARGETTING
+  const leadFormId = '#Company-Prospect-Form';
+  const pageRef = 'onSubmitCompanyProspectForm';
+  const formSubmitButtonSelector = 'input[type=submit]';
+  const formContainerClass = '.js-company-prospect-form';
+  let timeout_interval = 1000;
+  // END FORM TARGETING
+
+  // This needs to run regardless of whether JQuery has loaded
+  // Disable button
+  const button = document.querySelector(
+    `${leadFormId} ${formSubmitButtonSelector}`
+  );
+  button.setAttribute('disabled', 'disabled');
+  const label = button.value;
+  button.value = 'Loading...';
+
+  function enableSubmitButton() {
+    button.value = label;
+    button.removeAttribute('disabled');
+  }
+
+  // ------------------------------------------------------------------------------------------
+  window.$loaded(function () {
+    window.hasLoadedSelect2 = window.hasLoadedSelect2 ?? false;
+
+    window.$parsleyLoaded = function (cb) {
+      setTimeout(() => {
+        if (window.Parsley && window.ParsleyValidator) {
+          cb(window, document, parsley, undefined);
+          return;
+        }
+        $parsleyLoaded(cb);
+      }, 50);
+    };
+
+    window.$parsleyLoaded(function (window, document, parsley) {
+      const form = $(leadFormId);
+      const formContainer = $(formContainerClass)
+
+      const formSubmitButton = form.find(formSubmitButtonSelector);
+
+      function trackSubmission() {
+        var emailValue = form.find('#email').val();
+        var isPlaywrightTest =
+          emailValue.match(/^\s*playwrighttest@offerzen\.com\s*$/i) != null;
+
+        if (!isPlaywrightTest) {
+          var event = form.find('.js-analytics-event').text();
+          var action = form.find('.js-analytics-action').text();
+          var label = form.find('.js-analytics-label').text();
+          var category = form.find('.js-analytics-category').text();
+          var source = form.find('.js-analytics-source').text();
+
+          dataLayer.push({
+            event: event || 'Company Lead Form Submitted',
+            action: action || 'Lead Form Submitted',
+            label: label || 'Company Sign Up / Employer Landing Page',
+            category: category || 'Core',
+            source: source || 'Demand Sign Up',
+          });
+        }
+      }
+
+      function onSubmitForm(token, e) {
+        formSubmitButton.attr('disabled', true);
+        window.pageVariantMeasureEnd = btoa(new Date().getTime() / 1000);
+        let initialButtonValue = formSubmitButton.attr('value');
+        let dataWait = formSubmitButton.attr('data-wait');
+        formSubmitButton.attr('value', dataWait);
+        // get the value of the report_source query parameter should it be present and forward it onto form lead submission for analytics
+        let searchParams = new URLSearchParams(window.location.search);
+        const formData = new FormData(form[0]);
+        const formProperties = Object.fromEntries(formData.entries());
+
+        form.find('.recaptcha-error').hide();
+        form.find('.js-submit-error').hide();
+
+        if (form.parsley().validate()) {
+          form.find('.js-missing-fields').hide();
+
+          const prospectProperties = Object.assign({}, formProperties, {
+            referrer: location.href,
+            report_source: searchParams.get('report_source'),
+            'g-recaptcha-response-data': {
+              webflow: token,
+            },
+            page_variant_meta: `${window.pageVariantMeasureStart}-optimize-meta-${pageVariantMeasureEnd}`,
+          });
+
+          $.ajax({
+            type: 'POST',
+            url: '/api/company/prospects',
+            data: JSON.stringify({ company_prospect: prospectProperties }),
+            contentType: 'application/json',
+            headers: {
+              Accept: 'application/json',
+            },
+            success: function (data) {
+                setTimeout(() => {
+                  if (data.id) {
+                    $.ajax({
+                      type: 'GET',
+                      url: `/api/company/prospects/${data.id}`,
+                      contentType: 'application/json',
+                      headers: {
+                        Accept: 'application/json',
+                      },
+                      success: function (data) {
+                        switch (data.status) {
+                          case 401:
+                            formSubmitButton.attr('disabled', false);
+                            formSubmitButton.attr('value', initialButtonValue);
+                            const errorText = formContainer.find('.js-form-error')
+                            if (data.error == 'invalid_address') {
+                              errorText.text('Oops! We couldn’t validate your email. Please check that you are using your work email, then try again.')
+                              errorText.show();
+                            } else {
+                              errorText.text('This looks like a personal email address. Please use your work email address.')
+                              errorText.show();
+                            }
+                            break;
+                          case 200:
+                            //localStorage.setItem('prospect_id', .prospectId);
+                            trackSubmission();
+                            window.location.pathname = '/hire-developers/get-started';
+                            break;
+                          case 304:
+                          default:
+                            setPolling({
+                              ...polling,
+                              timeEllapsed: polling.timeEllapsed + pollingIntervalTime,
+                            });
+                        }
+                      },
+                    });
+                    
+                    return
+                  }
+                }, timeout_interval)
+                
+              }
+            },
+            // Reset form
+            error: function (data) {
+              formSubmitButton.attr('disabled', false);
+              formSubmitButton.attr('value', initialButtonValue);
+
+              if (data.recaptcha_verify) {
+                form.find('.recaptcha-error').show();
+              } else {
+                form.find('.js-submit-error').show();
+              }
+            },
+          });
+        } else {
+          form.find('.js-missing-fields').show();
+          formSubmitButton.attr('disabled', false);
+          formSubmitButton.attr('value', initialButtonValue);
+        }
+      }
+
+      function updateSubscribeToHiringInsightsField() {
+        subscribeToCompanyNewsletter = form.find(
+          '#subscribe_to_company_newsletter'
+        );
+        subscribeToCompanyNewsletter.on('change', function () {
+          form.find('#subscribe_to_hiring_insights').val(this.value);
+        });
+      }
+
+      function matchCheckboxStates() {
+        form.find('.w-checkbox').each(function () {
+          const el = $(this);
+          const inputField = el.find('.w-checkbox-input');
+          if (el.find('input[type=checkbox]').is(':checked')) {
+            inputField.addClass('w--redirected-checked');
+          } else {
+            inputField.removeClass('w--redirected-checked');
+          }
+        });
+      }
+
+      // ------------------------------------------------------------
+      // Setup form
+      // ------------------------------------------------------------
+
+      (function init() {
+        // Check Recaptcha error
+        const urlParams = new URLSearchParams(window.location.search);
+        if (urlParams.has('r')) {
+          form.find('.recaptcha-error').show();
+        }
+
+        function onFormReady() {
+          form.on('submit', function (e) {
+            e.preventDefault();
+            grecaptcha.ready(function () {
+              grecaptcha
+                .execute('6Lf802weAAAAAHgxndx9NIZ3FTzdG3f7nBua2rRY', {
+                  action: 'webflow',
+                })
+                .then(function (token) {
+                  onSubmitForm(token, e);
+                });
+            });
+          });
+
+          enableSubmitButton();
+        }
+
+        updateSubscribeToHiringInsightsField();
+        matchCheckboxStates();
+
+        // Still needed for other parts of the page
+        window[pageRef] = onSubmitForm;
+
+        onFormReady();
+      })();
+    });
+  });
+})();


### PR DESCRIPTION
### 🏗️ Changed
Added a new script to handle the shorter lead form on Webflow.
The script does the following:
- Polls the Growth End point for Clearout validation
- Updates the submit button text while polling is happening
- Updates the submit button text after 5 seconds if polling is not complete
- Redirects the user to the` /hire-developers/get-started` page on successful validation

### 🧪 Testing
The form can be tested on Webflow [here](https://offerzen.webflow.io/test-new-company-landing-page) 
