### PR TITLE
Force styling for active and focus state of MP filters

### DIFF
--- a/offerzen/global/company/marketplace-preview@2.0.css
+++ b/offerzen/global/company/marketplace-preview@2.0.css
@@ -1,0 +1,9 @@
+.js-filter-selected, 
+.js-filter-selected:active, 
+.js-filter-selected:focus, 
+.js-filter-selected:visited {
+  background-color: #2F96F4 !important;
+  border-color: #2F96F4 !important;
+  color: #ffffff !important;
+}
+


### PR DESCRIPTION
Why?
Webflow was overriding the styling of the filters on the Marketplace preview section for the active and focus states. 
Please check Megs video on this slack thread
**https://offerzen.slack.com/archives/G01761Q5KU1/p1669104561440069?thread_ts=1669103557.522489&cid=G01761Q5KU1**

What?
Explicitly cater for the different states and force styling bye adding `!important`

