### PR TITLE
Adds recruitics trigger

### DIFF
--- a/offerzen/global/candidate/onboarding.js
+++ b/offerzen/global/candidate/onboarding.js
@@ -1,8 +1,13 @@
 !(function() {
+  let counter = 0;
   const cb = function(e) {
-    if (rx && window.location.includes('area-roles')) {
+    if (rx && window.location.pathname.includes('/area-roles')) {
       rx.trigger('apply');
+      return
+    }
+    if (counter++ < 30) { // 2.5 minutes
+      setTimeout(cb, 5000)
     }
   }
-  window.addEventListener('popstate', cb, { once: true });
+  cb()
 })();

--- a/offerzen/global/candidate/onboarding.js
+++ b/offerzen/global/candidate/onboarding.js
@@ -1,1 +1,8 @@
-!(function() { if (rx) rx.trigger('apply'); })()
+!(function() {
+  const cb = function(e) {
+    if (rx && window.location.includes('area-roles')) {
+      rx.trigger('apply');
+    }
+  }
+  window.addEventListener('popstate', cb, { once: true });
+})();

--- a/offerzen/global/candidate/onboarding.js
+++ b/offerzen/global/candidate/onboarding.js
@@ -5,7 +5,7 @@
       rx.trigger('apply');
       return
     }
-    if (counter++ < 30) { // 2.5 minutes
+    if (counter++ < 50) { // 4 minutes
       setTimeout(cb, 5000)
     }
   }

--- a/offerzen/global/candidate/onboarding.js
+++ b/offerzen/global/candidate/onboarding.js
@@ -1,0 +1,1 @@
+!(function() { if (rx) rx.trigger('apply'); })()


### PR DESCRIPTION
Why
Recruitics scripts are very limited. We need to explicitly trigger an injected script from GTM. This will be removed soon. Needed due to burning performance marketing money

What
Adds a trigger script we can inject async via gtm on the area-roles page.

`popstate` didn't work on live. Recommendation is something like setInterval, so I implemented a safer version. There doesn't seem to be any actual API to do this in vanilla JS

Script is injected on signup page, and I remove it after 4 minutes regardless of success