### PR TITLE
Added pricing option param

### DIFF
--- a/offerzen/global/company-fast-track-access/company-prospect-form.js
+++ b/offerzen/global/company-fast-track-access/company-prospect-form.js
@@ -150,6 +150,7 @@
             report_source: searchParams.get('report_source'),
             page_variant_meta: `${window.pageVariantMeasureStart}-optimize-meta-${pageVariantMeasureEnd}`,
             access_option: `${option}`,
+            selected_pricing_option: searchParams.get('pricing_option')
           });
           $.ajax({
             type: 'POST',


### PR DESCRIPTION
**Why**
- [Asana task](https://app.asana.com/0/1202493047229733/1205749119445365/f)
- The change is required to send through the pricing option the user clicked on, when available. This data is required in HubSpot for the sales team to use.

**What**
Added an additional item to the `prospectProperties` that will send through to the farsight endpoint.
This property looks for the `pricing_option` query param in the url
