### PR TITLE
GS-627: Send email to GTM Data Layer when a company prospect signs up

### DIFF
--- a/offerzen/global/company-fast-track-access/company-prospect-form.js
+++ b/offerzen/global/company-fast-track-access/company-prospect-form.js
@@ -61,6 +61,7 @@
             label: label || 'Company Sign Up / Employer Landing Page',
             category: category || 'Core',
             source: source || 'Demand Sign Up',
+            email: emailValue
           });
         }
       }


### PR DESCRIPTION
### Why ❓ 
An Email Data layer variable needs to be created within tag manager and applied to company signup ([Google Demand lead form submit custom event](https://tagmanager.google.com/#/container/accounts/1959241284/containers/7797698/workspaces/369/tags)) conversion event tags.

### What changed 🚧 
send through email to the dataLayer